### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-deploy:
     name: Test deployment


### PR DESCRIPTION
Potential fix for [https://github.com/sebdanielsson/gik2f8-h21sebda-lab2/security/code-scanning/19](https://github.com/sebdanielsson/gik2f8-h21sebda-lab2/security/code-scanning/19)

To fix the issue, explicitly define the `permissions` key in the workflow file. Since the workflow does not require write access, the `contents` permission will be set to `read`. This will ensure that the `GITHUB_TOKEN` used in the workflow has the minimum necessary permissions.

The `permissions` key will be added at the root of the workflow file to apply to all jobs. This approach avoids redundancy and ensures consistency across all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
