### PR TITLE
Potential fix for code scanning alert no. 18: Reflected cross-site scripting

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 import express from "express";
 import fs from "fs/promises";
 import { rateLimit } from 'express-rate-limit'
+import escape from "escape-html";
 
 const app = express();
 const port = process.env.PORT || 80;
@@ -128,7 +129,7 @@ app.delete("/tasks/:id", async (req, res) => {
     } else {
       const newList = currentTasks.filter((task) => task.id != req.params.id);
       await fs.writeFile("./tasks.json", JSON.stringify(newList));
-      res.send("Task id " + req.params.id + " deleted.");
+      res.send("Task id " + escape(req.params.id) + " deleted.");
     }
   } catch (err) {
     log("Exception occurred", err.stack);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "@tailwindcss/cli": "^4.0.3",
     "express": "^5.0.0",
-    "express-rate-limit": "^8.0.0"
+    "express-rate-limit": "^8.0.0",
+    "escape-html": "^1.0.3"
   },
   "devDependencies": {
     "nodemon": "^3.1.9",


### PR DESCRIPTION
Potential fix for [https://github.com/sebdanielsson/gik2f8-h21sebda-lab2/security/code-scanning/18](https://github.com/sebdanielsson/gik2f8-h21sebda-lab2/security/code-scanning/18)

To fix the issue, sanitize the user-provided `req.params.id` before including it in the HTTP response. The best approach is to use an external library, such as `escape-html`, which ensures proper escaping of special characters to prevent execution as HTML/JavaScript. This fix maintains the existing functionality while preventing XSS vulnerabilities.

**Steps to fix:**
1. Import the `escape-html` library at the top of the file.
2. Replace the direct use of `req.params.id` in the response with `escape(req.params.id)` to ensure the user input is safely escaped.

**Required changes:**
- Add the `escape-html` dependency.
- Sanitize `req.params.id` in the response on line 131.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
